### PR TITLE
fix: removal of empty style elements in SSR handling

### DIFF
--- a/static/scripts/styled-components-fix.js
+++ b/static/scripts/styled-components-fix.js
@@ -2,8 +2,8 @@
 (function() {
   const styleElements = document.querySelectorAll('style[data-styled]');
   styleElements.forEach(style => {
-    if (style.innerHTML === '') {
+    if (style.sheet && style.sheet.cssRules.length === 0) {
       style.parentNode.removeChild(style);
     }
   });
-})(); 
+})();


### PR DESCRIPTION
Updated the code to fix the removal of empty `style` elements. Instead of relying on empty `innerHTML`, it now checks for `style.sheet` and ensures there are no CSS rules before removing the element.

This avoids potential issues with components that may add styles later.