### PR TITLE
fix: broken `initializeWithEthers` example

### DIFF
--- a/docs/devdocs/cofhejs/error-handling.md
+++ b/docs/devdocs/cofhejs/error-handling.md
@@ -126,9 +126,9 @@ async function initializeCoFHE() {
 		const signer = (await provider.getSigner()) as ethers.JsonRpcSigner
 
 		// initialize cofhejs Client with ethers (it also supports viem)
-		await cofhejs.initializeWithEthers({
-			provider: window.ethereum,
-			signer: wallet,
+		const result = await cofhejs.initializeWithEthers({
+			ethersProvider: provider,
+			ethersSigner: signer,
 			environment: 'TESTNET',
 		})
 


### PR DESCRIPTION
<!-- Fill in the task id in the following comment: -->
<!-- Monday Task ID: [TASK_ID] -->

Fixes an invalid code example in the Error Handling documentation where the result of `initializeWithEthers` was not captured and undefined variables were used.
The example now correctly stores the returned Result, uses consistent ethers provider/signer variables.
