### PR TITLE
Fix: undeclared variable

### DIFF
--- a/docs/devdocs/fhe-library/decryption-operations.md
+++ b/docs/devdocs/fhe-library/decryption-operations.md
@@ -64,7 +64,7 @@ function safelyRevealWinner() external onlyAuctioneer {
   require(bidReady, "Bid not yet decrypted");
 
   winningBid = bidValue;
-  emit RevealedWinningBid(bidderValue, bidValue);
+  emit RevealedWinningBid(winningBidder, bidValue);
 }
 ```
 
@@ -97,7 +97,7 @@ function unsafeRevealWinner() external onlyAuctioneer {
   uint64 bidValue = FHE.getDecryptResult(highestBid);
 
   winningBid = bidValue;
-  emit RevealedWinningBid(bidderValue, bidValue);
+  emit RevealedWinningBid(winningBidder, bidValue);
 }
 ```
 


### PR DESCRIPTION
<!-- Fill in the task id in the following comment: -->
<!-- Monday Task ID: [TASK_ID] -->

Replaced missing `bidderValue` in simplified safe and unsafe decryption examples with `winningBidder` to prevent compilation errors. Full contract examples already handle `bidderValue` correctly.
