### PR TITLE
fix: correct type mismatch in adding-FHE tutorial

### DIFF
--- a/docs/devdocs/tutorials/adding-FHE-to-existing-contract.md
+++ b/docs/devdocs/tutorials/adding-FHE-to-existing-contract.md
@@ -503,7 +503,7 @@ function getProposal(
     // If any of the results have not yet been decrypted, set `finalized` to false.
     // Store the decrypted result counts in the `votes` list to be returned.
     // diff-add
-    votes = new uint64[](proposal.options.length);
+    votes = new uint256[](proposal.options.length);
     // diff-add
     finalized = true;
     // diff-add
@@ -712,7 +712,7 @@ contract FHEVotingExample {
             options[i] = proposal.options[i].name;
         }
 
-        votes = new uint64[](proposal.options.length);
+        votes = new uint256[](proposal.options.length);
         finalized = true;
         for (uint8 i = 0; i < proposal.options.length; i++) {
             (uint256 result, bool decrypted) = FHE.getDecryptResultSafe(


### PR DESCRIPTION
## Summary

- Fixed `getProposal()` in the "Adding FHE to Existing Contract" tutorial where the return type declares `uint256[] memory votes` but the array is initialized as `uint64[]`, causing a **Solidity compilation error** for anyone following the tutorial
- Fixed in both the step-by-step diff section and the final complete contract listing

## Details

The mismatch appears in two places:
1. **Step-by-step section**: return type says `uint256[]`, init says `uint64[]`
2. **Final contract**: same mismatch

Both now correctly use `uint256[]` throughout.

## Test plan

- [ ] Verify the final contract in the tutorial compiles with `solc ^0.8.20`
- [ ] Confirm `getProposal()` return types match the initialization

Closes #138